### PR TITLE
chore(deps): update peer ngx-page-scroll-core

### DIFF
--- a/projects/ngx-page-scroll/package.json
+++ b/projects/ngx-page-scroll/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Nolanus/ngx-page-scroll#readme",
   "peerDependencies": {
-    "ngx-page-scroll-core": "6.0.0-beta.0",
+    "ngx-page-scroll-core": "6.0.0-beta.1",
     "@angular/common": "^7.1.0",
     "@angular/core": "^7.1.0"
   }


### PR DESCRIPTION
Hi,
I installed the latest versions of `ngx-page-scroll` and `ngx-page-scroll-core` corresponding to the docs.
The I get the following npm warning
`ngx-page-scroll@6.0.0-beta.1 requires a peer of ngx-page-scroll-core@6.0.0-beta.0 but none is installed. You must install peer dependencies yourself.`

If there is no reason for the older peer dependency, please accept the update.

Best Regards