### PR TITLE
Update ngx-page-scroll-core peerDependency

### DIFF
--- a/projects/ngx-page-scroll/package.json
+++ b/projects/ngx-page-scroll/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/Nolanus/ngx-page-scroll#readme",
   "peerDependencies": {
-    "ngx-page-scroll-core": "7.0.3",
+    "ngx-page-scroll-core": "~7.0.3",
     "@angular/common": "^8.0.0 || ^9.0.0 || ^10.0.5 || ^11.0.0",
     "@angular/core": "^8.0.0 || ^9.0.0 || ^10.0.5 || ^11.0.0"
   },


### PR DESCRIPTION
The peerDependency is not set to be in-sync with patch releases of ngx-page-scroll-core, causing peer dependency warnings